### PR TITLE
Improve attack engine

### DIFF
--- a/default_data/training/armageddon.json
+++ b/default_data/training/armageddon.json
@@ -1,114 +1,90 @@
 {
   "name": "Armageddon Mode",
-  "delayPerAttack": 1,
-  "attackCountPerDelay": 4,
   "mergeComboMetalQueue": true,
-  "attackpatterns": [
+  "delayBeforeStart": 150,
+  "delayBeforeRepeat": 91,
+  "attackPatterns": [
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 1,
       "metal": false,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 2,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 3,
       "metal": false,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 4,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 5,
       "metal": false,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 6,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 7,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 8,
       "metal": false,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 9,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 10,
       "metal": false,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 11,
       "metal": true,
       "chain": false
     },
     {
       "width": 1,
       "height": 1,
-      "startTime": 30,
-      "delay": 600,
-      "attackcount": null,
+      "startTime": 12,
       "metal": false,
       "chain": false
     }

--- a/default_data/training/bronze.json
+++ b/default_data/training/bronze.json
@@ -1,0 +1,48 @@
+{
+  "name": "Bronze",
+  "mergeComboMetalQueue": false,
+  "delayBeforeStart": 150,
+  "delayBeforeRepeat": 91,
+  "attackPatterns": [
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 300,
+      "chain": true
+    },
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 360,
+      "chain": true
+    },
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 420,
+      "chain": true
+    },
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 480,
+      "chain": true
+    },
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 540,
+      "chain": true
+    },
+    {
+      "startTime": 540,
+      "endsChain": true
+    },
+    {
+      "width": 6,
+      "height": 1,
+      "startTime": 600,
+      "chain": false
+    },
+  ]
+}

--- a/engine/GarbageQueue.lua
+++ b/engine/GarbageQueue.lua
@@ -22,7 +22,7 @@ GarbageQueue = class(function(s)
       for k,v in pairs(garbage) do
         local width, height, metal, from_chain, finalized = unpack(v)
         if width and height then
-          if metal and (GAME.battleRoom.trainingModeSettings and not GAME.battleRoom.trainingModeSettings.mergeComboMetalQueue) then
+          if metal and (GAME.battleRoom.trainingModeSettings == nil or not GAME.battleRoom.trainingModeSettings.mergeComboMetalQueue) then
             self.metal:push(v)
           elseif from_chain or (height > 1 and not GAME.battleRoom.trainingModeSettings) then
             if not from_chain then

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -563,17 +563,39 @@ local function main_endless_time_setup(mode, speed, difficulty, level)
 
 end
 
+local function createBasicTrainingMode(name, width, height) 
+
+  local delayBeforeStart = 150
+  local delayBeforeRepeat = 91
+  local attacksPerVolley = 6
+  local attackPatterns = {}
+  if height > 1 and width == 6 then -- chain
+    local chainEndTime = height + 1 + GARBAGE_TRANSIT_TIME
+    for i = 1, height + 1 do
+      local startTime = math.floor(i / (height + 1) * chainEndTime)
+      attackPatterns[#attackPatterns+1] = {width = width, height = 1, startTime = startTime, metal = false, chain = true, endsChain = false}
+    end
+    attackPatterns[#attackPatterns+1] = {width = width, height = 1, startTime = chainEndTime, metal = false, chain = true, endsChain = true}
+  else -- combo (or illegal garbage)
+    for i = 1, attacksPerVolley do
+      attackPatterns[#attackPatterns+1] = {width = width, height = height, startTime = i, metal = false, chain = false, endsChain = false}
+    end
+  end
+  local customTrainingModeData = {name = name, delayBeforeStart = delayBeforeStart, delayBeforeRepeat = delayBeforeRepeat, attackPatterns = attackPatterns}
+
+  return customTrainingModeData
+end
+
 function training_setup()
-  -- TODO make "illegal garbage blocks" possible again in telegraph.
   local trainingModeSettings = {}
   trainingModeSettings.height = 1
   trainingModeSettings.width = 4
   local customModeID = 1
   local customTrainingModes = {}
   customTrainingModes[0] = {name = "None"}
-  customTrainingModes[1] = {name = loc("combo_storm"), attackpatterns = {[1] = {width = 4, height = 1}}}
-  customTrainingModes[2] = {name = loc("factory"), attackpatterns = {[1] = {width = 6, height = 2}}}
-  customTrainingModes[3] = {name = loc("large_garbage"), attackpatterns = {[1] = {width = 6, height = 12}}}
+  customTrainingModes[1] = createBasicTrainingMode(loc("combo_storm"), 4, 1)
+  customTrainingModes[2] = createBasicTrainingMode(loc("factory"), 6, 2)
+  customTrainingModes[3] = createBasicTrainingMode(loc("large_garbage"), 6, 12)
   for customfile, value in ipairs(trainings) do
     customTrainingModes[#customTrainingModes+1] = value
   end
@@ -639,7 +661,7 @@ function training_setup()
   end
 
   local function start_custom_game()
-    customTrainingModes[0] = {attackpatterns = {[1] = {width = trainingModeSettings.width, height = trainingModeSettings.height}}}
+    customTrainingModes[0] = createBasicTrainingMode("", trainingModeSettings.width, trainingModeSettings.height)
     ret = {main_local_vs_yourself_setup, {customTrainingModes[customModeID]}}
   end
 

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -1326,14 +1326,16 @@ function select_screen.main()
       P1 = Stack{which=1, match=GAME.match, is_local=true, panels_dir=cursor_data[1].state.panels_dir, level=cursor_data[1].state.level, player_number=1, character=cursor_data[1].state.character}
 
       if GAME.battleRoom.trainingModeSettings then
-        GAME.match.attackEngine = AttackEngine(P1)
-        local delayPerAttack = GAME.battleRoom.trainingModeSettings.delayPerAttack or 6
-        local attackCountPerDelay = GAME.battleRoom.trainingModeSettings.attackCountPerDelay or 15
-        local delay = GARBAGE_TRANSIT_TIME + GARBAGE_TELEGRAPH_TIME + (attackCountPerDelay * delayPerAttack) + 1
+        local trainingModeSettings = GAME.battleRoom.trainingModeSettings
+        local delayBeforeStart = trainingModeSettings.delayBeforeStart or 0
+        local delayBeforeRepeat = trainingModeSettings.delayBeforeRepeat or 0
+        GAME.match.attackEngine = AttackEngine(P1, delayBeforeStart, delayBeforeRepeat)
 
-        for i = 1, attackCountPerDelay do
-          for patternid, values in ipairs(GAME.battleRoom.trainingModeSettings.attackpatterns) do
-            GAME.match.attackEngine:addAttackPattern(values.width or 4, values.height or 1, (values.startTime or 150) + (i * delayPerAttack) --[[start time]], delay + (values.delay or 0)--[[repeat]], values.attackcount--[[attack count]], values.metal --[[metal]],  values.chain or false--[[chain]]) 
+        for patternid, values in ipairs(trainingModeSettings.attackPatterns) do
+          if values.endsChain then
+            GAME.match.attackEngine:addEndChainPattern(values.startTime)
+          else
+            GAME.match.attackEngine:addAttackPattern(values.width, values.height, values.startTime, values.metal or false, values.chain)
           end
         end
       end


### PR DESCRIPTION
Instead of having attack count and repeat, assume all attacks repeat after the last one ends
Specifically add each chain and the chain end, so we can simulate real attacks better